### PR TITLE
Update with DOM's abort reason

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -326,9 +326,9 @@ When this method is invoked, the user agent MUST execute the following algorithm
         Only the [=domain=] format of [=host=] is allowed here. This is for simplification and also is
         in recognition of various issues with using direct IP address identification in concert with
         PKI-based security.
-1. If the <code>|options|.{{CredentialRequestOptions/signal}}</code> is [=present=] and its
-    [=AbortSignal/aborted flag=] is set to [TRUE], return a {{DOMException}} whose name is "{{AbortError}}"
-    and terminate this algorithm.
+1. If the <code>|options|.{{CredentialRequestOptions/signal}}</code> is [=present=] and
+    [=AbortSignal/aborted=], return the <code>|options|.{{CredentialRequestOptions/signal}}</code>'s
+    [=AbortSignal/abort reason=] and terminate this algorithm.
 1. TODO(goto): figure out how to connect the dots here with the transport algorithms.
 
 During the above process, the user agent SHOULD show some UI to the user to guide them in the process of sharing the OTP with the origin.

--- a/index.bs
+++ b/index.bs
@@ -327,7 +327,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
         in recognition of various issues with using direct IP address identification in concert with
         PKI-based security.
 1. If the <code>|options|.{{CredentialRequestOptions/signal}}</code> is [=present=] and
-    [=AbortSignal/aborted=], return the <code>|options|.{{CredentialRequestOptions/signal}}</code>'s
+    [=AbortSignal/aborted=], throw the <code>|options|.{{CredentialRequestOptions/signal}}</code>'s
     [=AbortSignal/abort reason=] and terminate this algorithm.
 1. TODO(goto): figure out how to connect the dots here with the transport algorithms.
 

--- a/index.bs
+++ b/index.bs
@@ -316,9 +316,9 @@ When this method is invoked, the user agent MUST execute the following algorithm
 1. Assert: <code>|options|.{{CredentialRequestOptions/otp}}</code> is [=present=].
 1. Let |options| be the value of <code>|options|.{{CredentialRequestOptions/otp}}</code>.
 1. Let |callerOrigin| be {{OTPCredential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)/origin}}.
-    If |callerOrigin| is an [=opaque origin=], return a {{DOMException}} whose name is "{{NotAllowedError}}", and terminate this algorithm.
+    If |callerOrigin| is an [=opaque origin=], throw a {{DOMException}} whose name is "{{NotAllowedError}}", and terminate this algorithm.
 1. Let |effectiveDomain| be the |callerOrigin|'s [=effective domain=].
-    If [=effective domain=] is not a [=valid domain=], then return a
+    If [=effective domain=] is not a [=valid domain=], then throw a
     {{DOMException}} whose name is "{{SecurityError}}" and terminate this algorithm.
 
         Note: An [=effective domain=] may resolve to a [=host=], which can be represented in various manners,


### PR DESCRIPTION
This change removes the reference to the deprecated "aborted flag" and uses the AbortSignal [aborted](https://dom.spec.whatwg.org/#dom-abortsignal-aborted) predicate and returns [abort reason](https://dom.spec.whatwg.org/#abortsignal-abort-reason) instead.

Fixes https://github.com/WICG/web-otp/issues/56.

/cc @nsatragno